### PR TITLE
Improve managing with multiple agents

### DIFF
--- a/src/agents/receptionist.py
+++ b/src/agents/receptionist.py
@@ -16,9 +16,8 @@ from .tools.currency_tools import detect_local_currency
 # ========== STATE ==========
 class RouterState(TypedDict):
     messages: Annotated[list, operator.add]
-    route: str
-    weather_result: str
-    exchange_result: str
+    routes: list[str]  # list of chosen routes to run
+    results: dict[str, str] # results from each specialized agent
 
 
 # ========== MODEL ==========
@@ -27,26 +26,31 @@ router_model = init_chat_model("anthropic:claude-sonnet-4-5", temperature=0)
 # ========== LLM DECISION NODE ==========
 def decide_route(state: RouterState):
     """LLM decides which specialized agent(s) to use."""
+
+    names = []
+    texts = []
+    for name, info in nodes.items():
+        names.append(f"'{name}'")
+        texts.append(f"- '{name}': {info['prompt']}")
+
     system_prompt = SystemMessage(
         content=(
             "You are a routing assistant. Given the user's request, decide which specialized agents "
             "should handle it.\n"
             "Available agents:\n"
-            "- 'weather': for weather forecasts or destinations.\n"
-            "- 'exchange': for currency or travel money queries.\n"
-            "You may choose 'weather', 'exchange', or 'both'. "
-            "Respond with only one word: weather, exchange, or both."
+            "\n".join(texts) + "\n"
+            "You may choose " + ", ".join(names) + "."
+            "You can choose multiple of it, respond with only those options seperated with a ','."
         )
     )
 
     decision = router_model.invoke([system_prompt] + state["messages"])
-    route = decision.content.strip().lower()
+    routes = decision.content.strip().lower().split(",")
 
-    # Normalize
-    if route not in ["weather", "exchange", "both"]:
-        route = "weather"  # fallback default
+    if len(routes) == 0:
+        routes = ["weather"]  # fallback default
 
-    return {"route": route}
+    return {"routes": routes}
 
 
 # ========== TOOL INVOCATION NODES ==========
@@ -56,7 +60,10 @@ def run_weather(state: RouterState):
     user_msg = state["messages"][-1].content
     res = weather_agent.invoke({"messages": [HumanMessage(content=user_msg)]})
     content = res["messages"][-1].content
-    return {"weather_result": content}
+
+    results = state.get("results", {})
+    results["weather"] = content
+    return {"results": results}
 
 
 def run_exchange(state: RouterState):
@@ -77,19 +84,24 @@ def run_exchange(state: RouterState):
         "messages": [system_msg, HumanMessage(content=user_msg)]
     })
     content = res["messages"][-1].content
-    return {"exchange_result": content}
+    
+    results = state.get("results", {})
+    results["exchange"] = content
+    return {"results": results}
 
 
 # ========== FINAL COMBINER NODE ==========
 def combine_results(state: RouterState):
     """Combine results from weather and exchange agents into a single, consistent response."""
-    weather = state.get("weather_result", "")
-    exchange = state.get("exchange_result", "")
-    
-    combined_text = "\n\n".join([r for r in [weather, exchange] if r])
-    
-    if not combined_text:
+    results = state.get("results", {})
+    texts = []
+    for key, text in results.items():
+        texts.append(text)
+
+    if len(texts) == 0:
         combined_text = "No relevant information found."
+    else:
+        combined_text = "\n\n".join(texts)
     
     # Use the router_model to merge into a single voice
     system_prompt = SystemMessage(
@@ -105,38 +117,49 @@ def combine_results(state: RouterState):
     return {"messages": [AIMessage(content=final_response.content)]}
 
 
+# node mapping
+#- callback: langraph node function to invoke
+#- prompt: description to send to AI prompt for routing decisions
+nodes = {
+    "weather": {
+        "callback": run_weather,
+        "prompt": "for weather forecasts or destinations",
+    },
+    "exchange": {
+        "callback": run_exchange,
+        "prompt": "for currency or travel money queries",
+    },
+}
+
+
 # ========== GRAPH ==========
 router_graph = StateGraph(RouterState)
 
 # nodes
 router_graph.add_node("decide_route", decide_route)
-router_graph.add_node("run_weather", run_weather)
-router_graph.add_node("run_exchange", run_exchange)
 router_graph.add_node("combine_results", combine_results)
+
+for name, info in nodes.items():
+    router_graph.add_node(name, info["callback"])
 
 # edges
 router_graph.add_edge(START, "decide_route")
 
 # conditional edges based on route decision
 def route_logic(state: RouterState):
-    route = state.get("route")
-    if route == "weather":
-        return "run_weather"
-    elif route == "exchange":
-        return "run_exchange"
-    elif route == "both":
-        return "run_weather"  # run weather first, then chain to exchange
-    else:
-        return "combine_results"
+    routes = state.get("routes")
+    
+    # Go through each routes that has not been run yet
+    for route in routes:
+        if route not in state.get("results", {}):
+            return route
 
-router_graph.add_conditional_edges("decide_route", route_logic,
-    ["run_weather", "run_exchange", "combine_results"]
-)
+    # After all routes have been run, go to combine_results
+    return "combine_results"
 
-# connect weather → exchange (for 'both' route)
-router_graph.add_edge("run_weather", "run_exchange")
-router_graph.add_edge("run_exchange", "combine_results")
-router_graph.add_edge("run_weather", "combine_results")  # in case route='weather' only
-router_graph.add_edge("run_exchange", "combine_results")
+router_graph.add_conditional_edges("decide_route", route_logic)
+
+for name in nodes.keys():
+    router_graph.add_conditional_edges(name, route_logic)
 
 receptionist = router_graph.compile()


### PR DESCRIPTION
This PR makes it all future-proof to allow able to easily add more agents into it, without needing to specify its agent scattered everywhere as all of the infos is in `nodes` dictionary to use.

This also removes the `both` keyword, AI would now instead return `weather,exchange`, separated by a `,` to list which agents to run.

Also fixes a bug where just "weather" prompt would still run exchange, also fixes `combine_results` get run multiple times when only needs to be done after all agents is done.